### PR TITLE
Translate user facing messages to English

### DIFF
--- a/lib/rules/declaration-order.js
+++ b/lib/rules/declaration-order.js
@@ -6,7 +6,7 @@ export default {
   meta: {
     type: "layout",
     docs: {
-      description: `Vue 3 <script setup>에서 선언 순서를 강제합니다.`,
+      description: `Forces declaration order in Vue 3 <script setup>`,
       category: "Stylistic Issues",
       recommended: true,
     },
@@ -69,7 +69,7 @@ export default {
         context.report({
           node: nonImportNodes[0],
           message:
-            "Vue 3 <script setup> 내 선언 순서가 올바르지 않습니다. 자동 수정(fix)을 적용합니다.",
+            "Vue 3 <script setup> declarations are not correctly sorted, run eslint with --fix to automatically fix this.",
           fix(fixer) {
             return fixer.replaceTextRange(fixRange, sortedText);
           },


### PR DESCRIPTION
Hi @KumJungMin, first of all, this plugin is amazing and exactly what my team needs, It checks all the boxes! I'm really impressed with it.
The only downside right now is that I'm afraid the Korean messages might confuse people.  
If this is something your team in particular needs, maybe we can look into a optional override for the message through the config?  
Otherwise I would just recommend translating it to English as all the documentation on this plugin also seems to be written in English as well.  
I also added a recommendation to run eslint with --fix instead of saying 'applying fix automatically' which is what I believe the original message was saying, because eslint will only apply the fix when running it with this argument, causing it to be possibly misleading.