### PR TITLE
feat: add composableAliases option to classify non-use* functions as …

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,63 @@ In this case:
 
 <br/>
 
+## 🛠 composableAliases Option
+By default, the rule treats function calls whose names start with `use` as composables. <br/>
+However, some utilities such as `storeToRefs` or `mapState` are composable in nature even though they do not follow the `use*` naming convention. <br/>
+You can classify those functions as composables by using the `composableAliases` option in `eslint.config.js`.
+
+### 📌 How It Works
+If a function name is included in `composableAliases`, declarations initialized from that call will be sorted in the `composables` section.
+
+Example:
+```js
+const store = storeToRefs();
+const state = mapState();
+```
+
+With the following configuration, both declarations above are treated as `composables`.
+
+### 📌 Configuration Example
+```js
+// eslint.config.js
+export default [
+  {
+    files: ["**/*.vue"],
+    languageOptions: {
+      parser: vueEslintParser,
+      parserOptions: {
+        parser: typescriptEslintParser,
+        ecmaVersion: 2022,
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "vue3-script-setup": {
+        rules: {
+          "declaration-order": eslintVueSetupOrderRule,
+        },
+      },
+    },
+    rules: {
+      "vue3-script-setup/declaration-order": [
+        "error",
+        {
+          composableAliases: ["storeToRefs", "mapState"], // this!!
+        },
+      ],
+    },
+  },
+];
+```
+
+### 📌 Result
+In this case:
+- `storeToRefs` will be treated as a composable.
+- `mapState` will be treated as a composable.
+- They will be sorted in the `composables` section even though their names do not start with `use`.
+
+<br/>
+
 ## 🛠 How to Apply
 ### 📌 Method 1: Install via npm
 ```

--- a/lib/rules/declaration-order.js
+++ b/lib/rules/declaration-order.js
@@ -32,6 +32,10 @@ export default {
             type: "object",
             additionalProperties: { type: "number" },
           },
+          composableAliases: {
+            type: "array",
+            items: { type: "string" },
+          },
         },
         additionalProperties: false,
       },
@@ -41,6 +45,7 @@ export default {
     const options = context.options[0] || {};
     const sectionOrder = options.sectionOrder || DEFAULT_SECTION_ORDER;
     const lifecycleOrder = options.lifecycleOrder || DEFAULT_LIFECYCLE_ORDER;
+    const composableAliases = new Set(options.composableAliases || []);
     validateSectionOrder(sectionOrder);
     return {
       /** @param {import('vue-eslint-parser').AST.Node} node */
@@ -79,6 +84,7 @@ export default {
             sourceCode,
             sectionOrder,
             lifecycleOrder,
+            composableAliases,
           }),
         );
 

--- a/lib/utils/astUtils.js
+++ b/lib/utils/astUtils.js
@@ -27,7 +27,7 @@ export function unwrapTypeCast(node) {
  * AST 노드를 분석하여 해당 노드가 속하는 섹션(그룹)을 반환합니다.
  * ImportDeclaration은 제외하며, 조건에 맞는 섹션이 없으면 "unknowns"를 반환합니다.
  */
-export function getSection(node) {
+export function getSection(node, composableAliases = new Set()) {
   switch (node.type) {
     case "ImportDeclaration":
       return null;
@@ -37,12 +37,12 @@ export function getSection(node) {
     case "TSInterfaceDeclaration":
       return "type";
     case "VariableDeclaration":
-      return getVariableDeclarationSection(node);
+      return getVariableDeclarationSection(node, composableAliases);
     case "FunctionDeclaration":
       return "functions";
     case "ExpressionStatement":
       if (isCallExpression(node.expression)) {
-        const section = getCallExpressionSection(node.expression.callee.name);
+        const section = getCallExpressionSection(node.expression.callee.name, composableAliases);
         if (section) return section;
       }
       return "unknowns";
@@ -51,7 +51,7 @@ export function getSection(node) {
   }
 }
 
-function getVariableDeclarationSection(node) {
+function getVariableDeclarationSection(node, composableAliases) {
   const declaration = node.declarations[0];
 
   if (declaration && declaration.init) {
@@ -63,7 +63,7 @@ function getVariableDeclarationSection(node) {
     ) {
       return "functions";
     } else if (isCallExpression(initNode)) {
-      const section = getCallExpressionSection(initNode.callee.name);
+      const section = getCallExpressionSection(initNode.callee.name, composableAliases);
 
       if (section) return section;
     }
@@ -78,7 +78,7 @@ function getVariableDeclarationSection(node) {
  * @description
  * CallExpression의 callee 이름에 따라 해당 섹션을 반환합니다.
  */
-export function getCallExpressionSection(calleeName) {
+export function getCallExpressionSection(calleeName, composableAliases = new Set()) {
   if (calleeName === "defineProps") return "defineProps";
   if (calleeName === "defineEmits") return "defineEmits";
   if (calleeName === "defineExpose") return "defineExpose";
@@ -86,13 +86,14 @@ export function getCallExpressionSection(calleeName) {
   if (calleeName === "defineModel") return "defineModel";
   if (calleeName === "defineOptions") return "defineOptions";
   if (DECLARE_LIST.includes(calleeName)) return "reactiveVars";
-  if (calleeName.startsWith("use")) return "composables";
+  if (calleeName.startsWith("use") || composableAliases.has(calleeName)) return "composables";
   if (calleeName === "computed") return "computed";
   if (calleeName === "watch") return "watchers";
   if (LIFECYCLE_LIST.includes(calleeName)) return "lifecycle";
 
   return null;
 }
+
 
 /**
  * @param {ASTNode} node

--- a/lib/utils/orderUtils.js
+++ b/lib/utils/orderUtils.js
@@ -15,8 +15,9 @@ export function createNodeWithSection({
   sourceCode,
   sectionOrder,
   lifecycleOrder,
+  composableAliases,
 }) {
-  const section = getSection(node);
+  const section = getSection(node, composableAliases);
   const text = sourceCode.getText(node);
   const idx = sectionOrder.indexOf(section);
   const sortIndex = idx !== -1 ? idx : sectionOrder.length;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-vue-setup-rules",
-  "version": "1.0.9",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-vue-setup-rules",
-      "version": "1.0.9",
+      "version": "1.0.13",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.20.0",

--- a/tests/declaration-order.test.js
+++ b/tests/declaration-order.test.js
@@ -131,6 +131,34 @@ onBeforeMount(() => {
 </script>
 `;
 
+const composableAliasesValidCode = `
+<script setup>
+const emits = defineEmits();
+
+const count = ref(0);
+
+const store = storeToRefs();
+</script>
+`;
+
+const composableAliasesInvalidCode = `
+<script setup>
+const store = storeToRefs();
+const count = ref(0);
+const emits = defineEmits();
+</script>
+`;
+
+const composableAliasesFixedCode = `
+<script setup>
+const emits = defineEmits();
+
+const count = ref(0);
+
+const store = storeToRefs();
+</script>
+`;
+
 ruleTester.run("declaration-order", rule, {
   valid: [
     {
@@ -156,6 +184,14 @@ ruleTester.run("declaration-order", rule, {
             onMounted: 0,
             onBeforeMount: 1,
           },
+        },
+      ],
+    },
+    {
+      code: composableAliasesValidCode,
+      options: [
+        {
+          composableAliases: ["storeToRefs"],
         },
       ],
     },
@@ -202,6 +238,20 @@ ruleTester.run("declaration-order", rule, {
         {
           message:
            ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: composableAliasesInvalidCode,
+      output: composableAliasesFixedCode,
+      options: [
+        {
+          composableAliases: ["storeToRefs"],
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
         },
       ],
     },


### PR DESCRIPTION
## Summary

Adds a new `composableAliases` rule option that allows users to specify function names that should be treated as composables, even if they don't follow the `use*` naming convention.

This is useful for third-party utilities like `storeToRefs` (Pinia) or other functions that are composable in nature but don't start with `use`.

## Changes

- **declaration-order.js**: Adds `composableAliases` to the rule schema and passes it down through the processing pipeline.
- **orderUtils.js**: Forwards `composableAliases` to `createNodeWithSection`.
- **astUtils.js**: 
  - Propagates `composableAliases` through `getSection` → `getVariableDeclarationSection` → `getCallExpressionSection` (fixes a pre-existing bug where `composableAliases` was not forwarded for `VariableDeclaration` nodes).
  - Extends the composable detection logic: `calleeName.startsWith("use") || composableAliases.has(calleeName)`.
- **declaration-order.test.js**: Adds valid and invalid test cases covering the new `composableAliases` option.

## Usage

```js
// eslint.config.js
rules: {
  "vue-setup-order/declaration-order": ["warn", {
    composableAliases: ["storeToRefs", "mapState"]
  }]
}
```