### PR TITLE
feat: comment support to prevent rule from moving a specific declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,33 @@ In this case:
 
 <br/>
 
+## 🛠 Pinning a Declaration in Place
+
+You can prevent the rule from moving a specific declaration by adding a `// eslint-vue-setup-order:keep` comment on the line immediately before it.
+
+### 📌 How It Works
+When the rule encounters a node with this marker it is treated as **pinned**: it stays at its original position in the source, and the remaining (non-pinned) declarations are sorted into the free slots around it.
+
+### 📌 Example
+
+```vue
+<script setup>
+// eslint-vue-setup-order:keep
+const count = ref(0);
+
+const emits = defineEmits();
+
+const hello = "Hello World!";
+</script>
+```
+
+Here `count` (a `reactiveVars` declaration) would normally be moved after `defineEmits` and `plainVars` declarations. Because it is pinned, it stays at the top while `emits` and `hello` are sorted into the remaining positions.
+
+> **Note:** The `// eslint-vue-setup-order:keep` comment must appear on the line **directly** before the declaration it pins. The comment itself is preserved as-is when the rule applies its auto-fix.
+
+
+<br/>
+
 ## 🛠 How to Apply
 ### 📌 Method 1: Install via npm
 ```

--- a/README.md
+++ b/README.md
@@ -235,13 +235,16 @@ In this case:
 
 ## 🛠 Pinning a Declaration in Place
 
-You can prevent the rule from moving a specific declaration by adding a `// eslint-vue-setup-order:keep` comment on the line immediately before it.
+You can prevent the rule from moving a specific declaration by adding a `// eslint-vue-setup-order:keep` comment **directly before** or **inline at the end of** the declaration line.
 
 ### 📌 How It Works
 When the rule encounters a node with this marker it is treated as **pinned**: it stays at its original position in the source, and the remaining (non-pinned) declarations are sorted into the free slots around it.
 
-### 📌 Example
+The comment must be **directly adjacent** to the declaration (no blank lines in between). If there is a blank line between the comment and the declaration, the comment will not pin the declaration.
 
+### 📌 Examples
+
+#### Leading comment (on the line before):
 ```vue
 <script setup>
 // eslint-vue-setup-order:keep
@@ -253,9 +256,30 @@ const hello = "Hello World!";
 </script>
 ```
 
-Here `count` (a `reactiveVars` declaration) would normally be moved after `defineEmits` and `plainVars` declarations. Because it is pinned, it stays at the top while `emits` and `hello` are sorted into the remaining positions.
+#### Inline comment (at the end of the line):
+```vue
+<script setup>
+const emits = defineEmits();
 
-> **Note:** The `// eslint-vue-setup-order:keep` comment must appear on the line **directly** before the declaration it pins. The comment itself is preserved as-is when the rule applies its auto-fix.
+const count = ref(0); // eslint-vue-setup-order:keep
+
+const hello = "Hello World!";
+</script>
+```
+
+#### Pinned in the middle:
+```vue
+<script setup>
+const hello = "Hello World!";
+// eslint-vue-setup-order:keep
+const count = ref(0);
+const emits = defineEmits();
+</script>
+```
+
+In all these examples, `count` (a `reactiveVars` declaration) stays in its original position while the other declarations are sorted into the remaining free slots around it.
+
+> **Note:** The `// eslint-vue-setup-order:keep` comment must be **directly adjacent** to the declaration it pins (either on the line immediately before or at the end of the same line). A blank line between the comment and the declaration breaks the adjacency and prevents pinning. The comment itself is preserved as-is when the rule applies its auto-fix.
 
 ## 🛠 composableAliases Option
 By default, the rule treats function calls whose names start with `use` as composables. <br/>

--- a/lib/rules/declaration-order.js
+++ b/lib/rules/declaration-order.js
@@ -91,7 +91,19 @@ export default {
         const sortedNodes = sortNodes(nodesWithSection);
         const groups = groupNodes(sortedNodes);
         const sortedText = generateSortedText(groups);
-        const fixRange = [nodes[0].range[0], nodes[nodes.length - 1].range[1]];
+        const firstNodeComments = (sourceCode.getCommentsBefore ? sourceCode.getCommentsBefore(nodes[0]) : [])
+          .filter((c) => {
+            const lineStart = sourceCode.text.lastIndexOf("\n", c.range[0] - 1) + 1;
+            return sourceCode.text.slice(lineStart, c.range[0]).trim() === "";
+          });
+        const fixStart = firstNodeComments.length > 0 ? firstNodeComments[0].range[0] : nodes[0].range[0];
+        const lastNode = nodes[nodes.length - 1];
+        const lastNodeInlineComments = (sourceCode.getCommentsAfter ? sourceCode.getCommentsAfter(lastNode) : [])
+          .filter((c) => c.loc.start.line === lastNode.loc.end.line);
+        const fixEnd = lastNodeInlineComments.length > 0
+          ? lastNodeInlineComments[lastNodeInlineComments.length - 1].range[1]
+          : lastNode.range[1];
+        const fixRange = [fixStart, fixEnd];
         const originalText = sourceCode.text.slice(fixRange[0], fixRange[1]);
 
         function normalizeLineEndings(str) {

--- a/lib/utils/orderUtils.js
+++ b/lib/utils/orderUtils.js
@@ -23,12 +23,35 @@ export function createNodeWithSection({
   const sortIndex = idx !== -1 ? idx : sectionOrder.length;
   const lifecycleSortIndex = section === "lifecycle" ? getLifecycleSortIndex(node, lifecycleOrder) : null;
   const KEEP_MARKER = "eslint-vue-setup-order:keep";
-  const comments = [
-    ...(sourceCode.getCommentsBefore ? sourceCode.getCommentsBefore(node) : []),
-    ...(sourceCode.getCommentsAfter ? sourceCode.getCommentsAfter(node) : []),
-  ];
-  const pinned = comments.some((c) => c.value.includes(KEEP_MARKER));
-  return { node, index, section, sortIndex, text, lifecycleSortIndex, pinned };
+  const leadingComments = sourceCode.getCommentsBefore ? sourceCode.getCommentsBefore(node) : [];
+  const trailingComments = sourceCode.getCommentsAfter ? sourceCode.getCommentsAfter(node) : [];
+  // Inline trailing comments = on the same line as the node's last token.
+  const inlineTrailingComments = trailingComments.filter(
+    (c) => c.loc.start.line === node.loc.end.line
+  );
+  // A "true" leading comment starts on its own line (no code before it on the same line).
+  // This excludes inline comments that belong to the previous statement but are also
+  // returned by getCommentsBefore() of the next node.
+  const trueLeadingComments = leadingComments.filter((c) => {
+    const lineStart = sourceCode.text.lastIndexOf("\n", c.range[0] - 1) + 1;
+    return sourceCode.text.slice(lineStart, c.range[0]).trim() === "";
+  });
+  // A leading comment pins the node only when directly adjacent (no blank line between).
+  const pinnedByLeading = trueLeadingComments.some(
+    (c) => c.value.includes(KEEP_MARKER) && c.loc.end.line + 1 === node.loc.start.line
+  );
+  // An inline trailing comment always pins the node it sits on.
+  const pinnedByInline = inlineTrailingComments.some((c) => c.value.includes(KEEP_MARKER));
+  const pinned = pinnedByLeading || pinnedByInline;
+  // Capture the raw text of true leading comments so they travel with the node.
+  const leadingCommentText = trueLeadingComments.length > 0
+    ? sourceCode.text.slice(trueLeadingComments[0].range[0], node.range[0])
+    : "";
+  // Capture the inline trailing comment text so it travels with the node.
+  const trailingInlineText = inlineTrailingComments.length > 0
+    ? sourceCode.text.slice(node.range[1], inlineTrailingComments[inlineTrailingComments.length - 1].range[1])
+    : "";
+  return { node, index, section, sortIndex, text, lifecycleSortIndex, pinned, leadingCommentText, trailingInlineText };
 }
 
 function getLifecycleSortIndex(node, lifecycleOrder) {
@@ -121,8 +144,12 @@ export function groupNodes(sortedNodes) {
  */
 export function generateSortedText(groups) {
   function getGroupText(group) {
-    const text = group.items.map(item => item.text).join("\n");
-    return normalizeNewlines(text);
+    const parts = group.items.map((item) => {
+      const nodeText = normalizeNewlines(item.text);
+      const withLeading = item.leadingCommentText ? item.leadingCommentText + nodeText : nodeText;
+      return item.trailingInlineText ? withLeading + item.trailingInlineText : withLeading;
+    });
+    return parts.join("\n");
   }
   return groups.map(getGroupText).join("\n\n");
 }

--- a/lib/utils/orderUtils.js
+++ b/lib/utils/orderUtils.js
@@ -21,8 +21,13 @@ export function createNodeWithSection({
   const idx = sectionOrder.indexOf(section);
   const sortIndex = idx !== -1 ? idx : sectionOrder.length;
   const lifecycleSortIndex = section === "lifecycle" ? getLifecycleSortIndex(node, lifecycleOrder) : null;
-
-  return { node, index, section, sortIndex, text, lifecycleSortIndex };
+  const KEEP_MARKER = "eslint-vue-setup-order:keep";
+  const comments = [
+    ...(sourceCode.getCommentsBefore ? sourceCode.getCommentsBefore(node) : []),
+    ...(sourceCode.getCommentsAfter ? sourceCode.getCommentsAfter(node) : []),
+  ];
+  const pinned = comments.some((c) => c.value.includes(KEEP_MARKER));
+  return { node, index, section, sortIndex, text, lifecycleSortIndex, pinned };
 }
 
 function getLifecycleSortIndex(node, lifecycleOrder) {
@@ -33,27 +38,44 @@ function getLifecycleSortIndex(node, lifecycleOrder) {
 }
 
 /**
- * @param {Array} nodesWithSection - 각 항목은 { node, index, section, sortIndex, text, lifecycleSortIndex } 구조입니다.
+ * @param {Array} nodesWithSection - 각 항목은 { node, index, section, sortIndex, text, lifecycleSortIndex, pinned } 구조입니다.
  * @returns {Array}
  * @description
  * 전체 노드를 sectionOrder에 따른 순서로 정렬합니다.
  * 같은 섹션 내에서는 원래 순서를 유지하되, lifecycle 그룹은 추가로 lifecycleSortIndex로 정렬합니다.
  */
 export function sortNodes(nodesWithSection) {
-  return nodesWithSection.slice().sort((a, b) => {
-    if (a.sortIndex !== b.sortIndex) {
-      return a.sortIndex - b.sortIndex;
-    }
-    if (a.section === "lifecycle" && b.section === "lifecycle") {
-      const aLifecycleSortIndex = typeof a.lifecycleSortIndex === "number" ? a.lifecycleSortIndex : Infinity;
-      const bLifecycleSortIndex = typeof b.lifecycleSortIndex === "number" ? b.lifecycleSortIndex : Infinity;
+  const n = nodesWithSection.length;
+  const result = new Array(n);
 
-      if (aLifecycleSortIndex !== bLifecycleSortIndex) {
-        return aLifecycleSortIndex - bLifecycleSortIndex;
-      }
+  // Place pinned nodes at their original positions
+  const pinnedIndexes = new Set();
+  nodesWithSection.forEach((item) => {
+    if (item.pinned) {
+      result[item.index] = item;
+      pinnedIndexes.add(item.index);
+    }
+  });
+
+  // Sort non-pinned nodes
+  const nonPinned = nodesWithSection.filter((item) => !item.pinned);
+  const sortedNonPinned = nonPinned.slice().sort((a, b) => {
+    if (a.sortIndex !== b.sortIndex) return a.sortIndex - b.sortIndex;
+    if (a.section === "lifecycle" && b.section === "lifecycle") {
+      const aL = typeof a.lifecycleSortIndex === "number" ? a.lifecycleSortIndex : Infinity;
+      const bL = typeof b.lifecycleSortIndex === "number" ? b.lifecycleSortIndex : Infinity;
+      if (aL !== bL) return aL - bL;
     }
     return a.index - b.index;
   });
+
+  // Fill free positions with sorted non-pinned nodes
+  const freePositions = Array.from({ length: n }, (_, i) => i).filter((i) => !pinnedIndexes.has(i));
+  freePositions.forEach((pos, i) => {
+    result[pos] = sortedNonPinned[i];
+  });
+
+  return result;
 }
 
 /**

--- a/tests/declaration-order.test.js
+++ b/tests/declaration-order.test.js
@@ -131,6 +131,41 @@ onBeforeMount(() => {
 </script>
 `;
 
+// A node marked with eslint-vue-setup-order:keep is pinned at its original position.
+// When the non-pinned nodes are already correctly ordered around it, the file is valid.
+const pinnedValidCode = `
+<script setup>
+// eslint-vue-setup-order:keep
+const count = ref(0);
+
+const emits = defineEmits();
+
+const hello = "Hello World!";
+</script>
+`;
+
+// The pinned node stays at index 0; the remaining non-pinned nodes (hello, emits) are
+// out of section order and must be sorted into the free positions around it.
+const pinnedInvalidCode = `
+<script setup>
+// eslint-vue-setup-order:keep
+const count = ref(0);
+const hello = "Hello World!";
+const emits = defineEmits();
+</script>
+`;
+
+const pinnedFixedCode = `
+<script setup>
+// eslint-vue-setup-order:keep
+const count = ref(0);
+
+const emits = defineEmits();
+
+const hello = "Hello World!";
+</script>
+`;
+
 ruleTester.run("declaration-order", rule, {
   valid: [
     {
@@ -158,6 +193,9 @@ ruleTester.run("declaration-order", rule, {
           },
         },
       ],
+    },
+    {
+      code: pinnedValidCode,
     },
   ],
   invalid: [
@@ -202,6 +240,15 @@ ruleTester.run("declaration-order", rule, {
         {
           message:
            ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: pinnedInvalidCode,
+      output: pinnedFixedCode,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
         },
       ],
     },

--- a/tests/declaration-order.test.js
+++ b/tests/declaration-order.test.js
@@ -194,6 +194,79 @@ const store = storeToRefs();
 </script>
 `;
 
+// blank line between marker and declaration → NOT treated as pinned.
+const pinnedBlankLineInvalidCode = `
+<script setup>
+const hello = "Hello World!";
+// eslint-vue-setup-order:keep
+
+const count = ref(0);
+const emits = defineEmits();
+</script>
+`;
+
+const pinnedBlankLineFixedCode = `
+<script setup>
+const emits = defineEmits();
+
+const hello = "Hello World!";
+
+// eslint-vue-setup-order:keep
+
+const count = ref(0);
+</script>
+`;
+
+// inline trailing comment also pins the declaration it sits on.
+const inlinePinnedValidCode = `
+<script setup>
+const emits = defineEmits();
+
+const count = ref(0); // eslint-vue-setup-order:keep
+
+const hello = "Hello World!";
+</script>
+`;
+
+const inlinePinnedInvalidCode = `
+<script setup>
+const hello = "Hello World!";
+const count = ref(0); // eslint-vue-setup-order:keep
+const emits = defineEmits();
+</script>
+`;
+
+const inlinePinnedFixedCode = `
+<script setup>
+const emits = defineEmits();
+
+const count = ref(0); // eslint-vue-setup-order:keep
+
+const hello = "Hello World!";
+</script>
+`;
+
+// a declaration in the middle of the file is pinnable.
+const middlePinnedInvalidCode = `
+<script setup>
+const hello = "Hello World!";
+// eslint-vue-setup-order:keep
+const count = ref(0);
+const emits = defineEmits();
+</script>
+`;
+
+const middlePinnedFixedCode = `
+<script setup>
+const emits = defineEmits();
+
+// eslint-vue-setup-order:keep
+const count = ref(0);
+
+const hello = "Hello World!";
+</script>
+`;
+
 ruleTester.run("declaration-order", rule, {
   valid: [
     {
@@ -224,6 +297,9 @@ ruleTester.run("declaration-order", rule, {
     },
     {
       code: pinnedValidCode,
+    },
+    {
+      code: inlinePinnedValidCode,
     },
     {
       code: composableAliasesValidCode,
@@ -296,6 +372,33 @@ ruleTester.run("declaration-order", rule, {
           composableAliases: ["storeToRefs"],
         },
       ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: pinnedBlankLineInvalidCode,
+      output: pinnedBlankLineFixedCode,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: middlePinnedInvalidCode,
+      output: middlePinnedFixedCode,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: inlinePinnedInvalidCode,
+      output: inlinePinnedFixedCode,
       errors: [
         {
           message: ERROR_MESSAGE,


### PR DESCRIPTION
## 🛠 Pinning a Declaration in Place

You can prevent the rule from moving a specific declaration by adding a `// eslint-vue-setup-order:keep` comment on the line immediately before it.

### 📌 How It Works
When the rule encounters a node with this marker it is treated as **pinned**: it stays at its original position in the source, and the remaining (non-pinned) declarations are sorted into the free slots around it.

### 📌 Example

```vue
<script setup>
// eslint-vue-setup-order:keep
const count = ref(0);

const emits = defineEmits();

const hello = "Hello World!";
</script>
```

Here `count` (a `reactiveVars` declaration) would normally be moved after `defineEmits` and `plainVars` declarations. Because it is pinned, it stays at the top while `emits` and `hello` are sorted into the remaining positions.

> **Note:** The `// eslint-vue-setup-order:keep` comment must appear on the line **directly** before the declaration it pins. The comment itself is preserved as-is when the rule applies its auto-fix.
