### PR TITLE
feat: add spaceBetweenItems option to improve declaration readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,64 @@ In this case:
 
 <br/>
 
+## 🛠 spaceBetweenItems Option
+By default, declarations within the same section are placed consecutively with no blank line between them. <br/>
+You can enable the `spaceBetweenItems` option to insert a blank line between every declaration inside a section, improving readability.
+
+### 📌 How It Works
+When `spaceBetweenItems` is set to `true`, each individual declaration within a section is separated by a blank line.
+Blank lines between different sections are always present regardless of this option.
+
+### 📌 Configuration Example
+```js
+// eslint.config.js
+export default [
+  {
+    files: ["**/*.vue"],
+    languageOptions: {
+      parser: vueEslintParser,
+      parserOptions: {
+        parser: typescriptEslintParser,
+        ecmaVersion: 2022,
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "vue3-script-setup": {
+        rules: {
+          "declaration-order": eslintVueSetupOrderRule,
+        },
+      },
+    },
+    rules: {
+      "vue3-script-setup/declaration-order": [
+        "error",
+        {
+          spaceBetweenItems: true, // <= like this
+        },
+      ],
+    },
+  },
+];
+```
+
+### 📌 Result
+
+Without `spaceBetweenItems` (default):
+```js
+const count = ref(0);
+const msg = ref("");
+```
+
+With `spaceBetweenItems: true`:
+```js
+const count = ref(0);
+
+const msg = ref("");
+```
+
+<br/>
+
 ## 🛠 How to Apply
 ### 📌 Method 1: Install via npm
 ```

--- a/lib/rules/declaration-order.js
+++ b/lib/rules/declaration-order.js
@@ -36,6 +36,9 @@ export default {
             type: "array",
             items: { type: "string" },
           },
+          spaceBetweenItems: {
+            type: "boolean",
+          },
         },
         additionalProperties: false,
       },
@@ -46,6 +49,7 @@ export default {
     const sectionOrder = options.sectionOrder || DEFAULT_SECTION_ORDER;
     const lifecycleOrder = options.lifecycleOrder || DEFAULT_LIFECYCLE_ORDER;
     const composableAliases = new Set(options.composableAliases || []);
+    const spaceBetweenItems = options.spaceBetweenItems ?? false;
     validateSectionOrder(sectionOrder);
     return {
       /** @param {import('vue-eslint-parser').AST.Node} node */
@@ -90,7 +94,7 @@ export default {
 
         const sortedNodes = sortNodes(nodesWithSection);
         const groups = groupNodes(sortedNodes);
-        const sortedText = generateSortedText(groups);
+        const sortedText = generateSortedText(groups, { spaceBetweenItems });
         const fixRange = [nodes[0].range[0], nodes[nodes.length - 1].range[1]];
         const originalText = sourceCode.text.slice(fixRange[0], fixRange[1]);
 

--- a/lib/utils/orderUtils.js
+++ b/lib/utils/orderUtils.js
@@ -97,8 +97,11 @@ export function groupNodes(sortedNodes) {
  * @description
  * 각 그룹 내 노드들은 "\n"으로 연결하고, 그룹 간에는 "\n\n"을 삽입한 최종 텍스트를 생성합니다.
  */
-export function generateSortedText(groups) {
+export function generateSortedText(groups, options = {}) {
   function getGroupText(group) {
+    if (options.spaceBetweenItems) {
+      return group.items.map(item => item.text.trim()).join("\n\n");
+    }
     const text = group.items.map(item => item.text).join("\n");
     return normalizeNewlines(text);
   }

--- a/tests/declaration-order.test.js
+++ b/tests/declaration-order.test.js
@@ -159,6 +159,55 @@ const store = storeToRefs();
 </script>
 `;
 
+const spaceBetweenItemsValidCode = `
+<script setup>
+const emits = defineEmits();
+
+const hello = "Hello World!";
+
+const count = ref(0);
+
+const msg = ref("");
+
+const changeMsg = () => {};
+
+function handleClick() {
+  emits("click");
+}
+</script>
+`;
+
+const spaceBetweenItemsInvalidCode = `
+<script setup>
+const hello = "Hello World!";
+const changeMsg = () => {};
+const emits = defineEmits();
+const count = ref(0);
+const msg = ref("");
+function handleClick() {
+  emits("click");
+}
+</script>
+`;
+
+const spaceBetweenItemsFixedCode = `
+<script setup>
+const emits = defineEmits();
+
+const hello = "Hello World!";
+
+const count = ref(0);
+
+const msg = ref("");
+
+const changeMsg = () => {};
+
+function handleClick() {
+  emits("click");
+}
+</script>
+`;
+
 ruleTester.run("declaration-order", rule, {
   valid: [
     {
@@ -192,6 +241,14 @@ ruleTester.run("declaration-order", rule, {
       options: [
         {
           composableAliases: ["storeToRefs"],
+        },
+      ],
+    },
+    {
+      code: spaceBetweenItemsValidCode,
+      options: [
+        {
+          spaceBetweenItems: true,
         },
       ],
     },
@@ -247,6 +304,20 @@ ruleTester.run("declaration-order", rule, {
       options: [
         {
           composableAliases: ["storeToRefs"],
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: spaceBetweenItemsInvalidCode,
+      output: spaceBetweenItemsFixedCode,
+      options: [
+        {
+          spaceBetweenItems: true,
         },
       ],
       errors: [


### PR DESCRIPTION

## feat: add `spaceBetweenItems` option

Closes #5

### Summary

Adds an optional `spaceBetweenItems` boolean configuration to the `declaration-order` rule, allowing users to insert a blank line between every declaration **within** a section.

By default the behavior is unchanged (`spaceBetweenItems: false`). When set to `true`, each individual declaration inside a section is separated by a blank line, improving readability.

### Changes

- **declaration-order.js** — Added `spaceBetweenItems` to the rule JSON schema and passed it to `generateSortedText`.
- **orderUtils.js** — `generateSortedText` now accepts an `options` argument; when `spaceBetweenItems` is `true`, items within the same group are joined with `\n\n` instead of collapsing blank lines.
- **declaration-order.test.js** — Added valid and invalid test cases covering the new option.
- **README.md** — Documented the new option with a configuration example and a before/after code snippet.

### Usage

```js
// eslint.config.js
rules: {
  "vue3-script-setup/declaration-order": ["error", { spaceBetweenItems: true }]
}
```

**Before:**
```js
const count = ref(0);
const msg = ref("");
```

**After:**
```js
const count = ref(0);

const msg = ref("");
```