### PR TITLE
fix: preserve blank lines inside declarations

### DIFF
--- a/lib/utils/orderUtils.js
+++ b/lib/utils/orderUtils.js
@@ -98,18 +98,8 @@ export function groupNodes(sortedNodes) {
  * 각 그룹 내 노드들은 "\n"으로 연결하고, 그룹 간에는 "\n\n"을 삽입한 최종 텍스트를 생성합니다.
  */
 export function generateSortedText(groups, options = {}) {
-  function getGroupText(group) {
-    if (options.spaceBetweenItems) {
-      return group.items.map(item => item.text.trim()).join("\n\n");
-    }
-    const text = group.items.map(item => item.text).join("\n");
-    return normalizeNewlines(text);
-  }
-  return groups.map(getGroupText).join("\n\n");
-}
-
-
-
-export function normalizeNewlines(text) {
-  return text.replace(/\n\s*\n/g, "\n").trim();
+  const itemSeparator = options.spaceBetweenItems ? "\n\n" : "\n";
+  return groups
+    .map((group) => group.items.map((item) => item.text).join(itemSeparator))
+    .join("\n\n");
 }

--- a/tests/declaration-order.test.js
+++ b/tests/declaration-order.test.js
@@ -208,6 +208,55 @@ function handleClick() {
 </script>
 `;
 
+const functionBodySpacingValidCode = `
+<script setup>
+const emits = defineEmits();
+
+function handleClick() {
+  if (true) {
+
+    emits("click");
+  }
+}
+</script>
+`;
+
+const functionBodySpacingInvalidCode = `
+<script setup>
+function handleClick() {
+  if (true) {
+
+    emits("click");
+  }
+}
+
+const emits = defineEmits();
+</script>
+`;
+
+const functionBodySpacingFixedCode = `
+<script setup>
+const emits = defineEmits();
+
+function handleClick() {
+  if (true) {
+
+    emits("click");
+  }
+}
+</script>
+`;
+
+const multilineComposableSpacingValidCode = `
+<script setup>
+const state = useFeature({
+  top: true,
+
+  bottom: false,
+});
+</script>
+`;
+
 ruleTester.run("declaration-order", rule, {
   valid: [
     {
@@ -251,6 +300,12 @@ ruleTester.run("declaration-order", rule, {
           spaceBetweenItems: true,
         },
       ],
+    },
+    {
+      code: functionBodySpacingValidCode,
+    },
+    {
+      code: multilineComposableSpacingValidCode,
     },
   ],
   invalid: [
@@ -320,6 +375,15 @@ ruleTester.run("declaration-order", rule, {
           spaceBetweenItems: true,
         },
       ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: functionBodySpacingInvalidCode,
+      output: functionBodySpacingFixedCode,
       errors: [
         {
           message: ERROR_MESSAGE,


### PR DESCRIPTION
> Closes #11

## Summary
- preserve each top-level declaration's original text when rebuilding sorted output
- stop collapsing blank lines inside function bodies and other multiline declaration blocks
- add regression coverage for function body spacing and multiline composable arguments

## Root Cause
The fixer normalized blank lines across the full declaration text while reassembling sorted output. That made `declaration-order` modify whitespace inside function declarations and other nested blocks instead of only controlling spacing between top-level declarations.


## Validation
- `npm test`
