### PR TITLE
test: split declaration-order cases by purpose

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha tests/all.test.js"
   },
   "keywords": [
     "eslint",

--- a/tests/all.test.js
+++ b/tests/all.test.js
@@ -1,0 +1,3 @@
+import "./declaration-order/core.test.js";
+import "./declaration-order/options.test.js";
+import "./declaration-order/regressions.test.js";

--- a/tests/declaration-order/core.test.js
+++ b/tests/declaration-order/core.test.js
@@ -1,0 +1,93 @@
+import { ruleTester, rule, ERROR_MESSAGE } from "./shared.js";
+
+const validCode = `
+<script setup>
+const emits = defineEmits();
+
+const hello = "Hello World!";
+
+const count = ref(0);
+const msg = ref("");
+
+onBeforeMount(() => {
+  console.log("onBeforeMount");
+});
+
+const changeMsg = () => {};
+function handleClick() {
+  emits("click");
+}
+</script>
+`;
+
+const invalidCode = `
+<script setup>
+const hello = "Hello World!";
+const changeMsg = () => {};
+const emits = defineEmits();
+onBeforeMount(() => {
+  console.log("onBeforeMount");
+});
+function handleClick() {
+  emits("click");
+}
+const count = ref(0);
+const msg = ref("");
+</script>
+`;
+
+const fixedCode = `
+<script setup>
+const emits = defineEmits();
+
+const hello = "Hello World!";
+
+const count = ref(0);
+const msg = ref("");
+
+onBeforeMount(() => {
+  console.log("onBeforeMount");
+});
+
+const changeMsg = () => {};
+function handleClick() {
+  emits("click");
+}
+</script>
+`;
+
+const ignoreNormalScript = `
+<script>
+const blah = () => {}
+const doNotReorderMe = true;
+</script>
+<script setup>
+const emits = defineEmits();
+
+const hello = "Hello World!";
+
+const changeMsg = () => {};
+</script>
+`;
+
+ruleTester.run("declaration-order: core", rule, {
+  valid: [
+    {
+      code: validCode,
+    },
+    {
+      code: ignoreNormalScript,
+    },
+  ],
+  invalid: [
+    {
+      code: invalidCode,
+      output: fixedCode,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+  ],
+});

--- a/tests/declaration-order/options.test.js
+++ b/tests/declaration-order/options.test.js
@@ -1,79 +1,4 @@
-import { RuleTester } from "eslint";
-import rule from "../lib/rules/declaration-order.js";
-import config from "./config.js";
-import {ERROR_MESSAGE} from "../lib/constants.js";
-
-const ruleTester = new RuleTester(config);
-
-const validCode = `
-<script setup>
-const emits = defineEmits();
-
-const hello = "Hello World!";
-
-const count = ref(0);
-const msg = ref("");
-
-onBeforeMount(() => {
-  console.log("onBeforeMount");
-});
-
-const changeMsg = () => {};
-function handleClick() {
-  emits("click");
-}
-</script>
-`;
-
-const invalidCode = `
-<script setup>
-const hello = "Hello World!";
-const changeMsg = () => {};
-const emits = defineEmits();
-onBeforeMount(() => {
-  console.log("onBeforeMount");
-});
-function handleClick() {
-  emits("click");
-}
-const count = ref(0);
-const msg = ref("");
-</script>
-`;
-
-const ignoreNormalScript = `
-<script>
-const blah = () => {}
-const doNotReorderMe = true;
-</script>
-<script setup>
-const emits = defineEmits();
-
-const hello = "Hello World!";
-
-const changeMsg = () => {};
-</script>
-`;
-
-const fixedCode = `
-<script setup>
-const emits = defineEmits();
-
-const hello = "Hello World!";
-
-const count = ref(0);
-const msg = ref("");
-
-onBeforeMount(() => {
-  console.log("onBeforeMount");
-});
-
-const changeMsg = () => {};
-function handleClick() {
-  emits("click");
-}
-</script>
-`;
+import { ruleTester, rule, ERROR_MESSAGE } from "./shared.js";
 
 const customValidCode = `
 <script setup>
@@ -208,63 +133,8 @@ function handleClick() {
 </script>
 `;
 
-const functionBodySpacingValidCode = `
-<script setup>
-const emits = defineEmits();
-
-function handleClick() {
-  if (true) {
-
-    emits("click");
-  }
-}
-</script>
-`;
-
-const functionBodySpacingInvalidCode = `
-<script setup>
-function handleClick() {
-  if (true) {
-
-    emits("click");
-  }
-}
-
-const emits = defineEmits();
-</script>
-`;
-
-const functionBodySpacingFixedCode = `
-<script setup>
-const emits = defineEmits();
-
-function handleClick() {
-  if (true) {
-
-    emits("click");
-  }
-}
-</script>
-`;
-
-const multilineComposableSpacingValidCode = `
-<script setup>
-const state = useFeature({
-  top: true,
-
-  bottom: false,
-});
-</script>
-`;
-
-ruleTester.run("declaration-order", rule, {
+ruleTester.run("declaration-order: options", rule, {
   valid: [
-    {
-      code: validCode,
-    },
-    {
-      code: ignoreNormalScript,
-    },
     {
       code: customValidCode,
       options: [
@@ -301,24 +171,8 @@ ruleTester.run("declaration-order", rule, {
         },
       ],
     },
-    {
-      code: functionBodySpacingValidCode,
-    },
-    {
-      code: multilineComposableSpacingValidCode,
-    },
   ],
   invalid: [
-    {
-      code: invalidCode,
-      output: fixedCode,
-      errors: [
-        {
-          message:
-           ERROR_MESSAGE,
-        },
-      ],
-    },
     {
       code: customInvalidCode,
       output: customFixedCode,
@@ -329,8 +183,7 @@ ruleTester.run("declaration-order", rule, {
       ],
       errors: [
         {
-          message:
-           ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -348,8 +201,7 @@ ruleTester.run("declaration-order", rule, {
       ],
       errors: [
         {
-          message:
-           ERROR_MESSAGE,
+          message: ERROR_MESSAGE,
         },
       ],
     },
@@ -375,15 +227,6 @@ ruleTester.run("declaration-order", rule, {
           spaceBetweenItems: true,
         },
       ],
-      errors: [
-        {
-          message: ERROR_MESSAGE,
-        },
-      ],
-    },
-    {
-      code: functionBodySpacingInvalidCode,
-      output: functionBodySpacingFixedCode,
       errors: [
         {
           message: ERROR_MESSAGE,

--- a/tests/declaration-order/regressions.test.js
+++ b/tests/declaration-order/regressions.test.js
@@ -1,0 +1,72 @@
+import { ruleTester, rule, ERROR_MESSAGE } from "./shared.js";
+
+const functionBodySpacingValidCode = `
+<script setup>
+const emits = defineEmits();
+
+function handleClick() {
+  if (true) {
+
+    emits("click");
+  }
+}
+</script>
+`;
+
+const functionBodySpacingInvalidCode = `
+<script setup>
+function handleClick() {
+  if (true) {
+
+    emits("click");
+  }
+}
+
+const emits = defineEmits();
+</script>
+`;
+
+const functionBodySpacingFixedCode = `
+<script setup>
+const emits = defineEmits();
+
+function handleClick() {
+  if (true) {
+
+    emits("click");
+  }
+}
+</script>
+`;
+
+const multilineComposableSpacingValidCode = `
+<script setup>
+const state = useFeature({
+  top: true,
+
+  bottom: false,
+});
+</script>
+`;
+
+ruleTester.run("declaration-order: regressions", rule, {
+  valid: [
+    {
+      code: functionBodySpacingValidCode,
+    },
+    {
+      code: multilineComposableSpacingValidCode,
+    },
+  ],
+  invalid: [
+    {
+      code: functionBodySpacingInvalidCode,
+      output: functionBodySpacingFixedCode,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+  ],
+});

--- a/tests/declaration-order/shared.js
+++ b/tests/declaration-order/shared.js
@@ -1,0 +1,7 @@
+import { RuleTester } from "eslint";
+import rule from "../../lib/rules/declaration-order.js";
+import config from "../config.js";
+import { ERROR_MESSAGE } from "../../lib/constants.js";
+
+export const ruleTester = new RuleTester(config);
+export { rule, ERROR_MESSAGE };


### PR DESCRIPTION
## Summary

- split the `declaration-order` test suite into purpose-based files
- add a shared test harness for common `RuleTester` setup
- add a single entry file so the whole suite still runs with one command

## Why

The existing test file had grown into a mixed set of core behavior, option coverage, and regression cases in one place. This change makes the suite easier to read, maintain, and extend without changing rule behavior.

## Changes

- added `tests/declaration-order/core.test.js` for baseline ordering behavior
- moved option-focused coverage into `tests/declaration-order/options.test.js`
- added `tests/declaration-order/regressions.test.js` for bug/regression cases
- added `tests/declaration-order/shared.js` for shared rule/test setup
- added `tests/all.test.js` as the single test entrypoint
- updated `npm test` to run the aggregated entry file

## Impact

- no runtime behavior changes
- test organization is clearer and easier to expand
- contributors can keep using a single command to run the full suite

## Validation

- `npm test`
