### PR TITLE
feat: extend spaceBetweenItems option

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,10 +340,17 @@ In this case:
 
 ## 🛠 spaceBetweenItems Option
 By default, declarations within the same section are placed consecutively with no blank line between them. <br/>
-You can enable the `spaceBetweenItems` option to insert a blank line between every declaration inside a section, improving readability.
+You can configure the `spaceBetweenItems` option to control blank lines between declarations inside the same section.
 
 ### 📌 How It Works
-When `spaceBetweenItems` is set to `true`, each individual declaration within a section is separated by a blank line.
+`spaceBetweenItems` supports both the original boolean values and string values:
+
+| Value | Behavior |
+| --- | --- |
+| `false` or `"never"` | Places declarations within the same section consecutively with no blank line. This is the default. |
+| `true` or `"always"` | Inserts a blank line between every declaration within the same section. |
+| `"preserve"` | Preserves existing blank lines between adjacent declarations within the same section when possible. |
+
 Blank lines between different sections are always present regardless of this option.
 
 ### 📌 Configuration Example
@@ -371,7 +378,7 @@ export default [
       "vue3-script-setup/declaration-order": [
         "error",
         {
-          spaceBetweenItems: true, // <= like this
+          spaceBetweenItems: "preserve", // or true / "always"
         },
       ],
     },
@@ -390,6 +397,14 @@ const msg = ref("");
 With `spaceBetweenItems: true`:
 ```js
 const count = ref(0);
+
+const msg = ref("");
+```
+
+With `spaceBetweenItems: "preserve"`:
+```js
+const count = ref(0);
+
 
 const msg = ref("");
 ```

--- a/lib/rules/declaration-order.js
+++ b/lib/rules/declaration-order.js
@@ -8,6 +8,7 @@ import {
   sortNodes,
   groupNodes,
   generateSortedText,
+  attachPreservedItemSeparators,
 } from "../utils/orderUtils.js";
 import { validateSectionOrder } from "../utils/astUtils.js";
 
@@ -37,7 +38,10 @@ export default {
             items: { type: "string" },
           },
           spaceBetweenItems: {
-            type: "boolean",
+            anyOf: [
+              { type: "boolean" },
+              { enum: ["never", "always", "preserve"] },
+            ],
           },
         },
         additionalProperties: false,
@@ -91,6 +95,7 @@ export default {
             composableAliases,
           }),
         );
+        attachPreservedItemSeparators(nodesWithSection, sourceCode);
 
         const sortedNodes = sortNodes(nodesWithSection);
         const groups = groupNodes(sortedNodes);

--- a/lib/utils/orderUtils.js
+++ b/lib/utils/orderUtils.js
@@ -51,7 +51,22 @@ export function createNodeWithSection({
   const trailingInlineText = inlineTrailingComments.length > 0
     ? sourceCode.text.slice(node.range[1], inlineTrailingComments[inlineTrailingComments.length - 1].range[1])
     : "";
-  return { node, index, section, sortIndex, text, lifecycleSortIndex, pinned, leadingCommentText, trailingInlineText };
+  const textStart = trueLeadingComments.length > 0 ? trueLeadingComments[0].range[0] : node.range[0];
+  const textEnd = inlineTrailingComments.length > 0
+    ? inlineTrailingComments[inlineTrailingComments.length - 1].range[1]
+    : node.range[1];
+  return {
+    node,
+    index,
+    section,
+    sortIndex,
+    text,
+    lifecycleSortIndex,
+    pinned,
+    leadingCommentText,
+    trailingInlineText,
+    textRange: [textStart, textEnd],
+  };
 }
 
 function getLifecycleSortIndex(node, lifecycleOrder) {
@@ -136,6 +151,17 @@ export function groupNodes(sortedNodes) {
   return groups;
 }
 
+export function attachPreservedItemSeparators(items, sourceCode) {
+  for (let i = 0; i < items.length - 1; i++) {
+    const current = items[i];
+    const next = items[i + 1];
+
+    if (groupName(current.section) !== groupName(next.section)) continue;
+
+    current.preservedSeparatorAfter = sourceCode.text.slice(current.textRange[1], next.textRange[0]);
+  }
+}
+
 /**
  * @param {Array} groups
  * @returns {string}
@@ -143,16 +169,41 @@ export function groupNodes(sortedNodes) {
  * 각 그룹 내 노드들은 "\n"으로 연결하고, 그룹 간에는 "\n\n"을 삽입한 최종 텍스트를 생성합니다.
  */
 export function generateSortedText(groups, options = {}) {
-  const itemSeparator = options.spaceBetweenItems ? "\n\n" : "\n";
+  const spacingMode = getSpaceBetweenItemsMode(options.spaceBetweenItems);
+  const itemSeparator = spacingMode === "always" ? "\n\n" : "\n";
+
+  function getItemSeparator(previous, next) {
+    if (spacingMode !== "preserve") return itemSeparator;
+
+    if (previous.index + 1 === next.index && previous.preservedSeparatorAfter !== undefined) {
+      return previous.preservedSeparatorAfter;
+    }
+
+    if (next.index + 1 === previous.index && next.preservedSeparatorAfter !== undefined) {
+      return next.preservedSeparatorAfter;
+    }
+
+    return "\n";
+  }
+
   function getGroupText(group) {
-    const parts = group.items.map((item) => {
+    return group.items.reduce((text, item, index) => {
       const nodeText = normalizeNewlines(item.text);
       const withLeading = item.leadingCommentText ? item.leadingCommentText + nodeText : nodeText;
-      return item.trailingInlineText ? withLeading + item.trailingInlineText : withLeading;
-    });
-    return parts.join(itemSeparator);
+      const itemText = item.trailingInlineText ? withLeading + item.trailingInlineText : withLeading;
+
+      if (index === 0) return itemText;
+
+      return text + getItemSeparator(group.items[index - 1], item) + itemText;
+    }, "");
   }
   return groups.map(getGroupText).join("\n\n");
+}
+
+function getSpaceBetweenItemsMode(spaceBetweenItems) {
+  if (spaceBetweenItems === true || spaceBetweenItems === "always") return "always";
+  if (spaceBetweenItems === "preserve") return "preserve";
+  return "never";
 }
 
 export function normalizeNewlines(text) {

--- a/tests/declaration-order/options.test.js
+++ b/tests/declaration-order/options.test.js
@@ -133,6 +133,45 @@ function handleClick() {
 </script>
 `;
 
+const spaceBetweenItemsNeverValidCode = `
+<script setup>
+const count = ref(0);
+const msg = ref("");
+</script>
+`;
+
+const preserveNewlinesBetweenItemsValidCode = `
+<script setup>
+function first() {
+  return 1;
+}
+
+
+function second() {
+  return 2;
+}
+</script>
+`;
+
+const preserveNewlinesBetweenItemsInvalidCode = `
+<script setup>
+const msg = ref("");
+
+const count = ref(0);
+const emits = defineEmits();
+</script>
+`;
+
+const preserveNewlinesBetweenItemsFixedCode = `
+<script setup>
+const emits = defineEmits();
+
+const msg = ref("");
+
+const count = ref(0);
+</script>
+`;
+
 ruleTester.run("declaration-order: options", rule, {
   valid: [
     {
@@ -168,6 +207,30 @@ ruleTester.run("declaration-order: options", rule, {
       options: [
         {
           spaceBetweenItems: true,
+        },
+      ],
+    },
+    {
+      code: spaceBetweenItemsValidCode,
+      options: [
+        {
+          spaceBetweenItems: "always",
+        },
+      ],
+    },
+    {
+      code: spaceBetweenItemsNeverValidCode,
+      options: [
+        {
+          spaceBetweenItems: "never",
+        },
+      ],
+    },
+    {
+      code: preserveNewlinesBetweenItemsValidCode,
+      options: [
+        {
+          spaceBetweenItems: "preserve",
         },
       ],
     },
@@ -225,6 +288,34 @@ ruleTester.run("declaration-order: options", rule, {
       options: [
         {
           spaceBetweenItems: true,
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: spaceBetweenItemsInvalidCode,
+      output: spaceBetweenItemsFixedCode,
+      options: [
+        {
+          spaceBetweenItems: "always",
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: preserveNewlinesBetweenItemsInvalidCode,
+      output: preserveNewlinesBetweenItemsFixedCode,
+      options: [
+        {
+          spaceBetweenItems: "preserve",
         },
       ],
       errors: [


### PR DESCRIPTION
## Summary

Closes #15

- Extended `spaceBetweenItems` to support string-based modes while preserving the existing boolean API.
- Added a new `"preserve"` mode to keep existing blank lines between adjacent items in the same section when possible.
- Documented the supported option values: `"never"`, `"always"`, and `"preserve"`.
- Added option tests for `"never"`, `"always"`, and `"preserve"`.

## Background

Previously, `spaceBetweenItems: true` always inserted a blank line between items, while the default behavior normalized adjacent items without blank lines.

This PR adds a `"preserve"` mode so users can keep the original spacing where possible, without breaking existing configurations that rely on the boolean API.

## Validation

- Ran `npm test`