### PR TITLE
feat: add sectionConfigurations option

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,57 @@ In this case:
 
 <br/>
 
+## 🛠 sectionConfigurations Option
+You can define custom section matching rules with the `sectionConfigurations` option.
+Each configuration is tested in the order it appears, before the built-in section detection runs.
+
+### 📌 How It Works
+Each configuration requires:
+- `sectionName`: the section assigned when the regex matches.
+- `regex`: a string pattern tested against the full declaration text.
+- `flags`: optional regular expression flags.
+
+The order of `sectionConfigurations` controls only matching precedence.
+It does **not** override `sectionOrder`.
+If you want a custom section to appear in a specific position, add that section name to `sectionOrder`.
+If the section is not present in `sectionOrder`, it is placed after configured sections.
+
+### 📌 Configuration Example
+```js
+// eslint.config.js
+export default [
+  {
+    files: ["**/*.vue"],
+    rules: {
+      "vue3-script-setup/declaration-order": [
+        "error",
+        {
+          sectionConfigurations: [
+            {
+              sectionName: "eventHandlers",
+              regex: "^function on",
+            },
+            {
+              sectionName: "functions",
+              regex: "^function ",
+            },
+          ],
+          sectionOrder: ["functions", "eventHandlers"],
+        },
+      ],
+    },
+  },
+];
+```
+
+### 📌 Result
+In this case:
+- `function onClick() {}` is treated as `eventHandlers`.
+- Other function declarations are treated as `functions`.
+- `functions` still appear before `eventHandlers` because `sectionOrder` controls output order.
+
+<br/>
+
 ## 🛠 spaceBetweenItems Option
 By default, declarations within the same section are placed consecutively with no blank line between them. <br/>
 You can enable the `spaceBetweenItems` option to insert a blank line between every declaration inside a section, improving readability.

--- a/lib/rules/declaration-order.js
+++ b/lib/rules/declaration-order.js
@@ -9,7 +9,10 @@ import {
   groupNodes,
   generateSortedText,
 } from "../utils/orderUtils.js";
-import { validateSectionOrder } from "../utils/astUtils.js";
+import {
+  normalizeSectionConfigurations,
+  validateSectionOrder,
+} from "../utils/astUtils.js";
 
 export default {
   meta: {
@@ -36,6 +39,19 @@ export default {
             type: "array",
             items: { type: "string" },
           },
+          sectionConfigurations: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                sectionName: { type: "string" },
+                regex: { type: "string" },
+                flags: { type: "string" },
+              },
+              required: ["sectionName", "regex"],
+              additionalProperties: false,
+            },
+          },
           spaceBetweenItems: {
             type: "boolean",
           },
@@ -49,8 +65,10 @@ export default {
     const sectionOrder = options.sectionOrder || DEFAULT_SECTION_ORDER;
     const lifecycleOrder = options.lifecycleOrder || DEFAULT_LIFECYCLE_ORDER;
     const composableAliases = new Set(options.composableAliases || []);
+    const sectionConfigurations = normalizeSectionConfigurations(options.sectionConfigurations || []);
+    const customSectionNames = new Set(sectionConfigurations.map((config) => config.sectionName));
     const spaceBetweenItems = options.spaceBetweenItems ?? false;
-    validateSectionOrder(sectionOrder);
+    validateSectionOrder(sectionOrder, customSectionNames);
     return {
       /** @param {import('vue-eslint-parser').AST.Node} node */
       "Program:exit"(node) {
@@ -89,6 +107,7 @@ export default {
             sectionOrder,
             lifecycleOrder,
             composableAliases,
+            sectionConfigurations,
           }),
         );
 

--- a/lib/utils/astUtils.js
+++ b/lib/utils/astUtils.js
@@ -27,7 +27,20 @@ export function unwrapTypeCast(node) {
  * AST 노드를 분석하여 해당 노드가 속하는 섹션(그룹)을 반환합니다.
  * ImportDeclaration은 제외하며, 조건에 맞는 섹션이 없으면 "unknowns"를 반환합니다.
  */
-export function getSection(node, composableAliases = new Set()) {
+export function getSection(node, options = {}) {
+  if (options instanceof Set) {
+    options = { composableAliases: options };
+  }
+
+  const {
+    composableAliases = new Set(),
+    sectionConfigurations = [],
+    text = "",
+  } = options;
+  const customSection = getCustomSection(text, sectionConfigurations);
+
+  if (customSection) return customSection;
+
   switch (node.type) {
     case "ImportDeclaration":
       return null;
@@ -50,6 +63,18 @@ export function getSection(node, composableAliases = new Set()) {
     default:
       return "unknowns";
   }
+}
+
+function getCustomSection(text, sectionConfigurations) {
+  for (const config of sectionConfigurations) {
+    config.pattern.lastIndex = 0;
+
+    if (config.pattern.test(text)) {
+      return config.sectionName;
+    }
+  }
+
+  return null;
 }
 
 function getVariableDeclarationSection(node, composableAliases) {
@@ -132,12 +157,14 @@ function isCallExpression(expression) {
  * @description 사용자가 전달한 sectionOrder 값이 유효한지 검사합니다.
  * @throws {Error} sectionOrder가 유효하지 않으면 예외를 발생시킵니다.
  */
-export function validateSectionOrder(sectionOrder) {
+export function validateSectionOrder(sectionOrder, customSectionNames = new Set()) {
   if (!Array.isArray(sectionOrder)) {
     throw new Error(
       `Invalid "sectionOrder" option: Expected an array, but received ${typeof sectionOrder}.`,
     );
   }
+
+  const validSections = [...DEFAULT_SECTION_ORDER, ...customSectionNames];
 
   for (const section of sectionOrder) {
     if (typeof section !== "string") {
@@ -145,14 +172,71 @@ export function validateSectionOrder(sectionOrder) {
         `Invalid "sectionOrder" option: Expected string values, but found ${typeof section}.`,
       );
     }
-    if (!DEFAULT_SECTION_ORDER.includes(section)) {
+    if (!validSections.includes(section)) {
       throw new Error(
-        `Invalid "sectionOrder" option: "${section}" is not a recognized section. Valid sections: ${DEFAULT_SECTION_ORDER.join(
+        `Invalid "sectionOrder" option: "${section}" is not a recognized section. Valid sections: ${validSections.join(
           ", ",
         )}`,
       );
     }
   }
+}
+
+export function normalizeSectionConfigurations(sectionConfigurations) {
+  if (!Array.isArray(sectionConfigurations)) {
+    throw new Error(
+      `Invalid "sectionConfigurations" option: Expected an array, but received ${typeof sectionConfigurations}.`,
+    );
+  }
+
+  return sectionConfigurations.map((config, index) => {
+    if (!config || typeof config !== "object") {
+      throw new Error(
+        `Invalid "sectionConfigurations[${index}]" option: Expected an object.`,
+      );
+    }
+
+    const { sectionName, regex, flags = "" } = config;
+
+    if (typeof sectionName !== "string") {
+      throw new Error(
+        `Invalid "sectionConfigurations[${index}].sectionName" option: Expected a string.`,
+      );
+    }
+
+    if (sectionName.trim() === "") {
+      throw new Error(
+        `Invalid "sectionConfigurations[${index}].sectionName" option: Expected a non-empty string.`,
+      );
+    }
+
+    if (typeof regex !== "string") {
+      throw new Error(
+        `Invalid "sectionConfigurations[${index}].regex" option: Expected a string.`,
+      );
+    }
+
+    if (typeof flags !== "string") {
+      throw new Error(
+        `Invalid "sectionConfigurations[${index}].flags" option: Expected a string.`,
+      );
+    }
+
+    let pattern;
+
+    try {
+      pattern = new RegExp(regex, flags);
+    } catch (error) {
+      throw new Error(
+        `Invalid "sectionConfigurations[${index}].regex" option: ${error.message}`,
+      );
+    }
+
+    return {
+      sectionName,
+      pattern,
+    };
+  });
 }
 
 /**

--- a/lib/utils/orderUtils.js
+++ b/lib/utils/orderUtils.js
@@ -16,9 +16,14 @@ export function createNodeWithSection({
   sectionOrder,
   lifecycleOrder,
   composableAliases,
+  sectionConfigurations,
 }) {
-  const section = getSection(node, composableAliases);
   const text = sourceCode.getText(node);
+  const section = getSection(node, {
+    composableAliases,
+    sectionConfigurations,
+    text,
+  });
   const idx = sectionOrder.indexOf(section);
   const sortIndex = idx !== -1 ? idx : sectionOrder.length;
   const lifecycleSortIndex = section === "lifecycle" ? getLifecycleSortIndex(node, lifecycleOrder) : null;

--- a/tests/all.test.js
+++ b/tests/all.test.js
@@ -2,4 +2,5 @@ import "./declaration-order/core.test.js";
 import "./declaration-order/options.test.js";
 import "./declaration-order/pinning.test.js";
 import "./declaration-order/regressions.test.js";
+import "./declaration-order/section-configurations.test.js";
 import "./declaration-order/typescript.test.js";

--- a/tests/declaration-order/section-configurations.test.js
+++ b/tests/declaration-order/section-configurations.test.js
@@ -1,0 +1,231 @@
+import { ruleTester, rule, ERROR_MESSAGE } from "./shared.js";
+
+const customSectionConfigurationsInvalidCode = `
+<script setup>
+const count = ref(0);
+const feature = useFeature();
+</script>
+`;
+
+const customSectionConfigurationsFixedCode = `
+<script setup>
+const feature = useFeature();
+
+const count = ref(0);
+</script>
+`;
+
+const customSectionWithoutOrderInvalidCode = `
+<script setup>
+const feature = useFeature();
+const count = ref(0);
+</script>
+`;
+
+const customSectionWithoutOrderFixedCode = `
+<script setup>
+const count = ref(0);
+
+const feature = useFeature();
+</script>
+`;
+
+const customSectionOrderInvalidCode = `
+<script setup>
+function onClick() {}
+function helper() {}
+</script>
+`;
+
+const customSectionOrderFixedCode = `
+<script setup>
+function helper() {}
+
+function onClick() {}
+</script>
+`;
+
+const composableAliasesCombinationInvalidCode = `
+<script setup>
+const count = ref(0);
+const store = storeToRefs();
+</script>
+`;
+
+const composableAliasesCombinationFixedCode = `
+<script setup>
+const store = storeToRefs();
+
+const count = ref(0);
+</script>
+`;
+
+const lifecycleOrderCombinationInvalidCode = `
+<script setup>
+onMounted(() => {});
+onBeforeMount(() => {});
+const feature = useFeature();
+</script>
+`;
+
+const lifecycleOrderCombinationFixedCode = `
+<script setup>
+const feature = useFeature();
+
+onBeforeMount(() => {});
+onMounted(() => {});
+</script>
+`;
+
+const spaceBetweenItemsCombinationInvalidCode = `
+<script setup>
+const other = useOther();
+const count = ref(0);
+const feature = useFeature();
+</script>
+`;
+
+const spaceBetweenItemsCombinationFixedCode = `
+<script setup>
+const other = useOther();
+
+const feature = useFeature();
+
+const count = ref(0);
+</script>
+`;
+
+ruleTester.run("declaration-order: sectionConfigurations", rule, {
+  valid: [],
+  invalid: [
+    {
+      code: customSectionConfigurationsInvalidCode,
+      output: customSectionConfigurationsFixedCode,
+      options: [
+        {
+          sectionConfigurations: [
+            {
+              sectionName: "dependencies",
+              regex: "\\buse[A-Z]\\w*\\(",
+            },
+          ],
+          sectionOrder: ["dependencies", "reactiveVars"],
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: customSectionWithoutOrderInvalidCode,
+      output: customSectionWithoutOrderFixedCode,
+      options: [
+        {
+          sectionConfigurations: [
+            {
+              sectionName: "dependencies",
+              regex: "\\buse[A-Z]\\w*\\(",
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: customSectionOrderInvalidCode,
+      output: customSectionOrderFixedCode,
+      options: [
+        {
+          sectionConfigurations: [
+            {
+              sectionName: "eventHandlers",
+              regex: "^function on",
+            },
+            {
+              sectionName: "functions",
+              regex: "^function ",
+            },
+          ],
+          sectionOrder: ["functions", "eventHandlers"],
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: composableAliasesCombinationInvalidCode,
+      output: composableAliasesCombinationFixedCode,
+      options: [
+        {
+          composableAliases: ["storeToRefs"],
+          sectionConfigurations: [
+            {
+              sectionName: "stateStores",
+              regex: "\\bstoreToRefs\\(",
+            },
+          ],
+          sectionOrder: ["stateStores", "reactiveVars"],
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: lifecycleOrderCombinationInvalidCode,
+      output: lifecycleOrderCombinationFixedCode,
+      options: [
+        {
+          lifecycleOrder: {
+            onBeforeMount: 0,
+            onMounted: 1,
+          },
+          sectionConfigurations: [
+            {
+              sectionName: "dependencies",
+              regex: "\\buse[A-Z]\\w*\\(",
+            },
+          ],
+          sectionOrder: ["dependencies", "lifecycle"],
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+    {
+      code: spaceBetweenItemsCombinationInvalidCode,
+      output: spaceBetweenItemsCombinationFixedCode,
+      options: [
+        {
+          sectionConfigurations: [
+            {
+              sectionName: "dependencies",
+              regex: "\\buse[A-Z]\\w*\\(",
+            },
+          ],
+          sectionOrder: ["dependencies", "reactiveVars"],
+          spaceBetweenItems: true,
+        },
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
> Related to #16

- Add a `sectionConfigurations` option for custom regex-based section matching.
- Evaluate custom section configurations before built-in section detection, using the configuration array order as matching precedence.
- Keep output ordering controlled by `sectionOrder`; `sectionConfigurations` does not override or automatically extend `sectionOrder`.
- Add dedicated `sectionConfigurations` tests, including conservative combinations with `sectionOrder`, `composableAliases`, `lifecycleOrder`, and `spaceBetweenItems`.
- Document the new option and its ordering behavior.

## Background

Some projects need to classify declarations in ways that do not fit the built-in section names. For example, a team may want to group selected `use*` calls as `dependencies`, or split functions into `functions` and `eventHandlers` using overlapping patterns.

This change keeps the two ordering concepts separate:

- `sectionConfigurations` controls which custom section a declaration matches.
- `sectionOrder` controls where that section appears after fixing.

If a custom section is not listed in `sectionOrder`, it is placed after configured sections rather than changing the configured order implicitly.


## Validation

- `npm test`